### PR TITLE
docs: note for GKE deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,9 +347,11 @@ Add the following to your project's pom.xml.
 
 ## Container Deployment
 
-While deploying this client in [Google Kubernetes Engine(GKE)](https://cloud.google.com/kubernetes-engine) with [CoS](https://cloud.google.com/container-optimized-os/docs/). Please make sure to provide CPU configuration in your deployment file. If `resources` are not configured than JVM would detect only 1 CPU, which affects the channel creation, resulting in performance degradation.
+While deploying this client in [Google Kubernetes Engine(GKE)](https://cloud.google.com/kubernetes-engine) with [CoS](https://cloud.google.com/container-optimized-os/docs/). Please make sure to provide CPU configuration in your deployment file. With default configuration JVM detects only 1 CPU, which affects the number of channels with the client, resulting in performance repercussion.
 
-For example when deploying this client on a cluster with 8 CPU nodes:
+Also, The number of `grpc-nio-worker-ELG-1-#` thread is same as number of CPUs. These are managed by a single `grpc-default-executor-#` thread, which is shared among multiple client instances.
+
+For example:
 ```yaml
 appVersion: v1
 ...
@@ -358,7 +360,7 @@ spec:
   container:
     resources:
       requests:
-        cpu: "1" # Here 1 represents 100% of single node CPUs(i.e. 8) whereas other than 1 represents the number of CPU it would use from a node.
+        cpu: "1" # Here 1 represents 100% of single node CPUs whereas other than 1 represents the number of CPU it would use from a node.
 ```
 see [Assign CPU Resources to Containers](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#specify-a-cpu-request-and-a-cpu-limit) for more information.
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,23 @@ Add the following to your project's pom.xml.
     </dependencyManagement>
 ```
 
+## Container Deployment
+
+While deploying this client in [Google Kubernetes Engine(GKE)](https://cloud.google.com/kubernetes-engine) with [CoS](https://cloud.google.com/container-optimized-os/docs/). Please make sure to provide CPU configuration in your deployment file. If `resources` are not configured than JVM would detect only 1 CPU, which affects the channel creation, resulting in performance degradation.
+
+For example when deploying this client on a cluster with 8 CPU nodes:
+```yaml
+appVersion: v1
+...
+spec:
+  ...
+  container:
+    resources:
+      requests:
+        cpu: "1" # Here 1 represents 100% of single node CPUs(i.e. 8) whereas other than 1 represents the number of CPU it would use from a node.
+```
+see [Assign CPU Resources to Containers](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#specify-a-cpu-request-and-a-cpu-limit) for more information.
+
 ## Troubleshooting
 
 To get help, follow the instructions in the [shared Troubleshooting


### PR DESCRIPTION
This change contains a note for deployment in GKE. If no configuration
is provided the JVM in CoS detects only 1 CPU/Core, which restrain the
number of channels resulting in performance loss.

